### PR TITLE
Allow Grafana CSV local mode

### DIFF
--- a/grafana-csv/docker-compose.yml
+++ b/grafana-csv/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_INSTALL_PLUGINS=marcusolsson-csv-datasource
     volumes:
+      - ./grafana.ini:/etc/grafana/grafana.ini
       - ./provisioning:/etc/grafana/provisioning
       - ./csv:/var/lib/grafana/csv
 

--- a/grafana-csv/grafana.ini
+++ b/grafana-csv/grafana.ini
@@ -1,0 +1,2 @@
+[plugin.marcusolsson-csv-datasource]
+allow_local_mode = true


### PR DESCRIPTION
## Summary
- configure Grafana CSV datasource to enable local mode
- mount custom grafana.ini in docker-compose

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68484c0eb384832483f284650f8cc355